### PR TITLE
Docs: go-boilerplate 機能移植候補インベントリを追加

### DIFF
--- a/docs/go-boilerplate-feature-port-candidates.md
+++ b/docs/go-boilerplate-feature-port-candidates.md
@@ -1,0 +1,127 @@
+# go-boilerplate 機能移植候補インベントリ
+
+隣接リポジトリ `go-boilerplate` の**リポジトリ機能そのもの**(make ターゲット / CI / スクリプト / ドキュメント基盤 / セキュリティ運用)を調査し、本リポジトリをアプリケーションファウンデーション / プロダクションレディへ引き上げるために移植価値のある要素を抽出したもの。
+
+- 調査日: 2026-07-11 / 対象スナップショット: `go-boilerplate` (`makefile` include 37 本 / `.makefiles/` 12 分類 / `.github/workflows/` 26 本 / `scripts/` 11 種)
+- **[BACKLOG.md](adr/BACKLOG.md) の「go-boilerplate Claude 資産 移植バックログ」(`.claude/` スキル・エージェント)とは別軸**。本書はリポジトリ機能が対象。ただし着手トリガーは同じ BACKLOG 枠 ID に紐づける
+- 言語差(Go → TS)は書き換え前提のため障害としない。Go 実装のものは「TS 書換」と明記
+
+## 判定の前提: nextjs-boilerplate の現状
+
+| 領域 | 現状 |
+| --- | --- |
+| `.makefiles/` | `github/`(release-branch / release-tag / setup-repository / branch-ruleset / labels / gh-login)と `tools/setup.mk` のみ移植済 |
+| `scripts/` | `make_help.sh` / `semver.ts` / `setup/`(license 書換のみ)移植済 |
+| `.github/` | ISSUE_TEMPLATE / PR テンプレ / settings(branch-protection.json, labels.json)/ release/ 移植済。**workflows/ は存在しない**(B9 未決定) |
+| Git hooks | Toolchain-0006(lefthook)は **Accepted だが未実装**(G2 = ✅/⬜)。lefthook 自体が未導入 |
+| 品質ゲート | `pnpm lint / fix / format`(biome)のみ。markdown / mermaid / secret / 脆弱性の検査は無い |
+| ドキュメント | `docs/adr/` のみ。portal 基盤は無い(D2 未決定) |
+
+## 凡例
+
+- **移植方式**: `as-is` = ほぼ無翻案 / `TS 書換` = 概念流用・実装書き直し / `パターン` = 骨格のみ流用し中身は本リポ向けに再設計
+- **ブロッカー**: BACKLOG 枠 ID。`—` = 保留領域に踏み込まず今すぐ移植可能(AGENTS.md の Instruction Priority 内で完結)
+
+---
+
+## Tier A: 今すぐ移植可能(ADR ブロッカーなし)
+
+ローカル実行の make ターゲット + スクリプト群。`.github/workflows/` に触れず、既存 ADR(0001/0002/0003/Toolchain-0005/0006)の範囲内で完結する。
+
+| # | 機能 | go 側の実体 | 移植方式 | 備考 |
+| --- | --- | --- | --- | --- |
+| A-1 | **lefthook 導入**(pre-commit / commit-msg / pre-push) | `.lefthook.yaml` | パターン | **G2 の実装ギャップ解消そのもの**(ADR は Accepted 済)。glob スコープ + parallel 実行 / pre-push に secret-scan・drift check を置く構成が参考。`pnpm add -D -E lefthook` |
+| A-2 | **commitlint**(コミット規約の機械検査) | `commitlint.config.js` + `.makefiles/github/commitlint.mk` | as-is | prefix 11 種(`Feat\|Fix\|...`)は本リポの Dev-0002 と完全同一。config はほぼコピー可。lefthook commit-msg に接続(A-1 依存)。現状は規約が文書のみで無検査 |
+| A-3 | **markdownlint**(`md-lint` / `md-fix`) | `.makefiles/markdown/lint.mk`(markdownlint-cli2)+ `.markdownlint.yaml` | as-is | ADR / BACKLOG / スキル等 md 資産が多い本リポで即効性が高い。除外 glob(`#glob` 構文、Make 内では `\#` エスケープ)と `AGENTS.md` 除外の知見ごと移植 |
+| A-4 | **mermaid 構文 lint**(`md-mermaid-lint`) | `scripts/mermaid-lint.mjs` | as-is | markdownlint が見ない図の文法を本物の `mermaid.parse` で検証。linkedom で DOM shim / exit 1(lint 失敗)と exit 2(環境異常)の区別が CI 向き。BACKLOG.md の依存マップ等 mermaid を既に使用 |
+| A-5 | **secret スキャン**(`secret-scan`) | `.makefiles/security/gitleaks.mk` + `.gitleaks.toml` | as-is | `gitleaks dir . --no-banner --redact`(`--redact` で検出値の二次漏洩を防止)。B10 は CI 組込みの決定待ちだが、**ローカル make ターゲット + pre-push hook までは Toolchain-0006 の範囲**で導入可 |
+| A-6 | **依存脆弱性スキャン**(`trivy-fs`) | `.makefiles/security/trivy.mk` | as-is | `trivy fs --scanners vuln --pkg-types library --ignore-unfixed --severity CRITICAL,HIGH,MEDIUM` は pnpm lockfile も対象。Toolchain-0005 の `pnpm audit` を補完(DB が異なる)。`--skip-dirs` は `node_modules` に読み替え |
+| A-7 | **actionlint**(`actions-lint`) | `.makefiles/github/lint.mk` | as-is | workflows が生えた瞬間に必要になる。make ターゲット自体は先行導入しても害がない(B9 決定後の受け皿) |
+| A-8 | **make help の未文書化警告** | `scripts/make_help.mjs` | as-is | `.PHONY` 行に `## 説明` が無いものを stderr 警告する自己文書化の強制。既存 `make_help.sh` との差分確認のうえ置換 or 追補 |
+| A-9 | **セットアップスクリプトの拡充** | `scripts/setup/`(`replace-repository-reference.mjs` / `replace-app-metadata.mjs` / `remove-sample-api` の宣言的マニフェスト + マーカーコメント方式) | パターン | 本リポは license 書換のみ移植済。README の URL / バッジ書換、`package.json` name 書換(Go module rename の翻案)を追加。共有 lib(commander `--dry-run` / `updateFile` / 再帰列挙)は流用可 |
+| A-10 | **mise へのツール登録**(`npm:` バックエンド) | `mise.toml` の `npm:markdownlint-cli2` / `npm:@commitlint/cli` 等の pin 方式 | as-is | A-2〜A-7 のツール版管理を `mise.toml` SSOT(ADR 0003)に載せる際の手本。`tools-upgrade` スキルはこの複数バックエンド形式を既に想定済 |
+
+**推奨着手順**: A-1(lefthook)→ A-2(commitlint)→ A-3/A-4(md lint)→ A-5/A-6(security)→ A-8〜A-10。A-1〜A-4 だけで「コミット規約・ドキュメント品質の機械検査」が閉じる。
+
+> 注: A-1 の `.lefthook.yaml`、A-2〜A-6 のルート設定ファイル追加と `package.json` / `mise.toml` 変更は AGENTS.md の保護対象なので、実施時は都度ユーザ指示が必要。
+
+---
+
+## Tier B: CI 基盤(B9 決定待ち — ADR 策定時の設計材料)
+
+`.github/workflows/` は B9(CI 構成方針)未決定のため追加不可。go 側の 26 本の workflows から、**B9 の ADR を書くときにそのまま設計材料になるもの**を抽出。B9 決定が最優先のアンブロック条件。
+
+### B-1. 全 workflow 共通の衛生規約(そのまま規約化推奨)
+
+- 全 `uses:` を **SHA ピン + `# vX.Y.Z` コメント**で固定(→ B-3)
+- `concurrency: ${{ github.workflow }}-${{ github.ref }}` + `cancel-in-progress: true`(deploy 系のみ false)
+- トップレベル `permissions: contents: read`、job 単位で最小昇格
+- 「`set +e` で実行 → ログを tee → 成否を outputs 化 → **失敗してもログを PR コメントに必ず残す** → 最後に fail」という共通骨格
+
+### B-2. PR コメント基盤: `upsert-pr-comment` composite action
+
+`.github/actions/upsert-pr-comment/`。HTML コメントマーカーで冪等 upsert / `<details>` 折り畳み / 45,000 字トランケート / commit SHA + JST タイムスタンプのフッタ。**全 CI レポーティングの背骨で、完全に言語非依存 → as-is 移植**。
+
+### B-3. Actions SHA ピン留め機構
+
+`scripts/pin-actions/`(Go)+ `.github/actions-pin.toml`(lockfile SSOT)+ `pin-actions-check.yaml`。`--min-age-days=14` の**サプライチェーン検疫**(新しすぎるコミットを採用しない = `tools-upgrade` スキルと同思想)。**TS 書換が必要**。BACKLOG **C-6(actions-pin スキル)と同じ枠**で、スキル(運用)と check(CI ゲート)をセットで移植するのが正。
+
+### B-4. 本リポに直接対応物がある CI チェック(翻案表)
+
+| go 側 | 本リポでの対応物 | 移植方式 |
+| --- | --- | --- |
+| `go-lint`(golangci-lint) | `pnpm lint`(biome)+ `tsc --noEmit` | パターン(骨格 = B-1/B-2 に載せるだけ) |
+| `go-test` + `cover-gate`(閾値 90%)+ octocov | B8 決定後の `pnpm test` + カバレッジゲート | パターン(B8 待ち) |
+| `tidy-check`(go.mod drift) | `pnpm install --frozen-lockfile` での lockfile drift 検査 | パターン |
+| `app-di-startup-check`(boot smoke) | `pnpm build` → `next start` → `curl /` の起動スモーク | パターン。「具象に依存しない起動検証」の思想ごと |
+| `secret-scan` / `trivy-fs` workflows | A-5 / A-6 の CI 側(B10 と同時決定) | as-is に近い |
+| `code-ql`(Go) | `languages: javascript-typescript` に差替。**PR + push baseline + 週次 cron `0 0 * * 1`** の三段トリガー設計ごと | as-is に近い |
+| `trivy-release-gate` | dev PR = fixable のみ / release PR = unfixed 含む全量、の**二段構え**設計 | as-is に近い |
+| `sync-versions-check` | mise.toml SSOT → CI の node 版数の drift 検査(workflows 導入後に意味を持つ) | TS 書換(小規模) |
+| gen 系 artifacts-check 三兄弟 | B4(型生成)導入後の「生成物 drift 検査 + **ソース起因か生成器起因かの triage コメント**」 | パターン(B4 待ち) |
+| `deploy-docs`(GitHub Pages) | D2(portal)採用時の docs 配信 | as-is |
+| `auto-generate-docs`(bot が生成物更新 PR を自動作成) | 再帰防止 guard(`github-actions[bot]` / `[skip ci]` / branch prefix)+ 非決定性出力の除去 + `peter-evans/create-pull-request` | パターン |
+| `dependabot.yml` | `npm` + `github-actions` ecosystem。**cooldown 段階制(patch 5 日 / minor 7 日 / major 30 日)+ ecosystem 単位のグループ PR** | as-is(B10) |
+
+**対象外(移植しない)**: `deploy-app`(GHCR build / cosign 署名 / SLSA attestation — ADR 0004 no-docker に非互換。PaaS デプロイは各プラットフォーム連携に委ねる)/ `image-scan` / `docker-lint` / `sql-lint` / `migration-check` / `setup-postgres` composite / `govulncheck`(→ `pnpm audit` が既に相当)。
+
+---
+
+## Tier C: ドキュメント基盤(D1 / D2 決定待ち)
+
+| # | 機能 | go 側の実体 | 移植方式 | ブロッカー |
+| --- | --- | --- | --- | --- |
+| C-1 | **docs ポータル一式** | `docs/portal/manifest.yaml`(構造の SSOT)+ `scripts/gen-portal-docs.mjs`(curated copy, zod 検証 + path-traversal guard)+ `scripts/gen-docs-json.mjs`(ナビ JSON 生成)+ `scripts/build-portal.mjs`(esbuild SPA, mermaid は遅延 UMD)+ React SPA(hash routing / Fuse.js 検索 / marked / highlight.js) | as-is に近い(**Go 結合ゼロ**。manifest 中身・EN/JA パス規約・除外リストの差替のみ) | **D2**。採用時は BACKLOG「対象外(D)」の `portal-manifest-sync` スキルも復活。`readme-review` スキルは manifest.yaml を既に前提にしている |
+| C-2 | **EN canonical / JA 翻訳ペア運用** | `docs/ja/` ミラー + `.ja.md` 規約 + 各 README ペア | パターン | **D1**。`canonicalize-doc` スキル(移植済)が実務を既にカバー — 決めるのは規約側 |
+| C-3 | **ADR タクソノミー** | decision / **exclusion**(意図的な不採用を `setup-review` タグ付きで残す)/ rule / inventory の 4 分類 + 採択後不変・supersede 運用 | パターン | 本リポの BACKLOG「out of scope」節が exclusion の萌芽。`adr-scan` スキル(移植済)がこの分類を既に使用。採番規約は本リポの系列プレフィックス方式を維持 |
+| C-4 | **SECURITY.md**(報告窓口) | `.github/SECURITY.md` 前半(Private Vulnerability Reporting / 報告要件 / 対応 SLA) | as-is(前半のみ) | **B10**。後半(cosign / attestation 検証 runbook)はコンテナ配送前提で対象外 |
+| C-5 | **workflows README 規約** | `.github/workflows/README.md`(トリガー戦略表 + 一覧表 + 設計ノート) | パターン | B9 と同時 |
+
+## Tier D: 環境変数・設定(A7 決定待ち — 参照設計)
+
+A7(環境変数管理)の ADR を書くときの**リファレンス実装**。今は持ち込まない。
+
+- **`env/` レイアウト**: `env/.env.{local,ci,dev,stg,prd}` + README を正とした変数表(`{SUBSYSTEM}_{NAME}` 規約 / 型列 / Secret 要否列 / 「Code default」マーカー)。Next.js 標準の `.env.local` 系との整合が論点
+- **型付き Config loader 三点セット**: `envspec`(タグ駆動の入力仕様)→ `model`(private field + getter の不変 Config)→ `config.go`(parse → validate → 明示的マッピング、"parse, don't validate")。TS では **zod schema → `Object.freeze` した型付き config → factory** に素直に写像できる。Next.js 固有の追加軸は **`NEXT_PUBLIC_` の client/server 境界**
+- 移植済スキル `new-env` の再設計(Dev-0005 記載)はこの決定とセットで行う
+
+## Tier E: テスト基盤(B8 決定待ち — 参照パターン)
+
+- **カバレッジゲート**: `cover-gate`(閾値 90% を下回ると CI fail)+ octocov による PR レポート
+- **test / test-cached の二層**: CI = キャッシュ無効 + race 相当の厳格版 / pre-commit = キャッシュ有効の高速版、という速度と厳密性の分離
+- BACKLOG C-5(テスト scaffold スキル)と同じトリガーで着手
+
+---
+
+## 移植しない(不適用)一覧
+
+ADR 0004(no-docker / 表示層ロール)と非互換、または Go / DB 固有:
+
+`.makefiles/app/`(serve / job / worker / outbox-relay / tool-runners)、`.makefiles/database/`(migrate / seed / dml-merge / SchemaSpy)、`.makefiles/sql/`(sqlfluff)、`.makefiles/docker/`(hadolint)、`.makefiles/go/`(fmt / golangci / sqlc / tidy / sync-versions 実装)、godoc 生成、`genctxkey`、docker tool-runner ラッパ層全般(本リポは pnpm / mise 直実行)。OpenAPI 系(redocly / `stamp-openapi-version.mjs`)は**不適用ではなく B4 の採否待ち**。
+
+## 総括: 推奨ロードマップ
+
+1. **即時(ブロッカーなし)**: Tier A = lefthook(G2 実装ギャップ解消)→ commitlint → markdownlint + mermaid-lint → gitleaks / trivy のローカルターゲット。これだけで「フック + 品質検査」のファウンデーション層が閉じる
+2. **次の ADR 決定を推奨**: **B9(CI)+ B10(セキュリティ運用)をセットで策定** — Tier B の材料はほぼ揃っており、翻案コストが低い(共通骨格 + upsert-pr-comment + lint/lockfile/build スモーク + CodeQL + trivy 二段 + dependabot)。Tier A を先に入れておくと lefthook(速い検査)↔ CI(権威検査)の二重化構造(G2 の設計)がそのまま成立する
+3. **中期**: D1/D2(ドキュメント運用 + portal)→ Tier C。A7 → Tier D。B8 → Tier E
+4. 各着手時は該当枠の Accepted 化と、AGENTS.md 保護対象(ルート設定 / `.github/` / `.claude/`)への都度ユーザ指示を確認する

--- a/docs/plan/go-boilerplate-feature-port-plan.md
+++ b/docs/plan/go-boilerplate-feature-port-plan.md
@@ -1,0 +1,161 @@
+# go-boilerplate 機能移植 作業計画書
+
+[docs/go-boilerplate-feature-port-candidates.md](../go-boilerplate-feature-port-candidates.md)(移植候補インベントリ)を実行可能な作業計画に落とし込んだもの。インベントリが「何を移植するか」を定義し、本書は「どの順で・どの単位で・何をもって完了とするか」を定義する。
+
+- 作成日: 2026-07-11
+- 対象: インベントリの Tier A〜E(Tier = 着手可能性の段階。本書の Phase と 1:1 対応)
+- 進捗管理: 各 Phase 完了時に [docs/adr/BACKLOG.md](../adr/BACKLOG.md) の該当枠(選定済み / 実装済み)を更新する
+
+## 全体方針
+
+1. **1 Phase = 1 つ以上の PR、1 PR = 1 機能群**。巨大 PR を作らない。各 PR は単独でマージ可能な状態(検証込み)で閉じる
+2. **保護対象パスは都度ユーザ指示**。ルート設定ファイル(`package.json` / `mise.toml` / `Makefile` / `.lefthook.yaml` 等)・`.github/`・`.claude/` に触れる作業は、着手前にユーザへ変更内容を提示して承認を得る(AGENTS.md「AI Modification Scope」)
+3. **ADR が必要な Phase は「ADR 策定 → Accepted → 実装」の順を厳守**。保留領域に独自規約を先行して持ち込まない
+4. **ツール追加は Toolchain-0005 に従う**: コア dev ツールは exact pin(`pnpm add -D -E`)、追加時に `pnpm audit` 実施、メジャー更新は別 PR
+5. コミットは Dev-0002 の prefix 規約(`Build:` / `CI:` / `Docs:` / `Chore:` 中心)。作業は `/commit` / `/submit-pr` スキル経由で行う
+
+## 依存関係マップ
+
+```mermaid
+flowchart LR
+    P1["Phase 1<br/>フック + 品質検査<br/>(ブロッカーなし)"]
+    ADR["B9 + B10<br/>ADR 策定"]
+    P2["Phase 2<br/>CI 基盤"]
+    P3["Phase 3<br/>docs ポータル<br/>(D1/D2)"]
+    P4["Phase 4<br/>環境変数 (A7)"]
+    P5["Phase 5<br/>テスト基盤 (B8)"]
+    P1 --> ADR --> P2
+    P2 -. deploy-docs .-> P3
+    P1 -.先行推奨.-> P2
+```
+
+Phase 1 は今すぐ着手可能。Phase 2 は B9/B10 の ADR 策定が前提。Phase 3〜5 は各 ADR(D1/D2・A7・B8)の決定順に独立して着手でき、相互依存は薄い(Phase 3 の Pages 配信のみ Phase 2 の workflows 導入後)。
+
+---
+
+## Phase 1: フック + 品質検査基盤(Tier A)
+
+**ゴール**: lefthook(G2 実装ギャップ)を核に、コミット規約・ドキュメント品質・シークレット / 脆弱性のローカル検査を閉じる。ADR ブロッカーなし。
+
+### PR 1-1: lefthook + commitlint(インベントリ A-1, A-2)
+
+| 項目 | 内容 |
+| --- | --- |
+| 作業 | ① `pnpm add -D -E lefthook @commitlint/cli`(+ `pnpm audit`)② `.lefthook.yaml` 新規作成(pre-commit: `pnpm lint` の glob スコープ実行 / commit-msg: commitlint)③ `commitlint.config.js` を go 側からコピー(prefix 11 種は Dev-0002 と同一のため無翻案)④ `.makefiles/tools/setup.mk` に `activate-tools`(`pnpm exec lefthook install`)を追加 ⑤ `.makefiles/github/commitlint.mk` を移植(docker ラッパ除去、直接実行) |
+| 触る保護対象 | `package.json` / `.lefthook.yaml`(新規)/ `commitlint.config.js`(新規)/ `Makefile`(include 追加)/ `.makefiles/` |
+| 完了条件 | 不正 prefix のコミットが commit-msg で拒否される / biome 違反ファイルのコミットが pre-commit で拒否される / `make help` に新ターゲットが説明付きで出る |
+| 検証 | わざと失敗するコミットを作って拒否を確認 → 正しいコミットが通ることを確認。`pnpm lint` / `pnpm build` 成功 |
+| BACKLOG 反映 | **G2 を ✅/✅ に更新**。repo-ops スキルの「lefthook 未導入」記述の更新をユーザに提案 |
+
+決定ポイント(着手時にユーザ確認): commitlint の管理を devDependency(exact pin)にするか mise `npm:` バックエンドにするか。**推奨: devDependency**(lefthook と同居、Toolchain-0006 の記述とも整合)。
+
+### PR 1-2: markdownlint + mermaid lint(A-3, A-4)
+
+| 項目 | 内容 |
+| --- | --- |
+| 作業 | ① `pnpm add -D -E markdownlint-cli2` と mermaid / linkedom(mermaid-lint 用)② `.markdownlint.yaml` を go 側から移植(ルール取捨選択)③ `scripts/mermaid-lint.mjs` を移植(除外リストを本リポ向けに変更: `node_modules` / `.git` / `AGENTS.md`。`vendor` / `docs/portal/guides` 等は現状不要)④ `.makefiles/markdown/lint.mk` を移植(`md-lint` / `md-fix` / `md-mermaid-lint`、docker ラッパ除去。`MD_GLOBS` の `\#` エスケープ知見を維持)⑤ `.lefthook.yaml` の pre-commit に `md-lint` を glob(`*.md`)付きで追加 |
+| 触る保護対象 | `package.json` / `Makefile` / `.makefiles/` / `.lefthook.yaml` / `.markdownlint.yaml`(新規) |
+| 完了条件 | `make md-lint` が既存 md 全件で成功(初回は指摘の一括修正コミットを分離)/ 壊れた mermaid フェンスで exit 1、依存欠落で exit 2 になる |
+| 検証 | 既存 `docs/adr/BACKLOG.md` の mermaid 図がパースを通ること。故意に壊した図で fail を確認 |
+
+注意: biome は Markdown 対象外(コミット `df1254c`)のため markdownlint と競合しない。初回 lint で既存 md に大量指摘が出る場合、ルール緩和か一括 `md-fix` かをユーザに確認する。
+
+### PR 1-3: セキュリティスキャン(A-5, A-6)
+
+| 項目 | 内容 |
+| --- | --- |
+| 作業 | ① `mise.toml` に gitleaks / trivy を追加(`aqua:` バックエンド。バージョンは `tools-upgrade` スキルの検疫基準で選定)② `.gitleaks.toml` を移植(allowlist は本リポ向けに最小化)③ `.makefiles/security/` を移植(`secret-scan`: `gitleaks dir . --no-banner --redact` / `trivy-fs`: `--skip-dirs node_modules` に読み替え)④ `.lefthook.yaml` の pre-push に `secret-scan` を追加 |
+| 触る保護対象 | `mise.toml` / `Makefile` / `.makefiles/` / `.lefthook.yaml` / `.gitleaks.toml`(新規) |
+| 完了条件 | `make secret-scan` / `make trivy-fs` が成功 / ダミーシークレットを置いた push が pre-push で拒否される |
+| 検証 | テスト用シークレット文字列で検出 → `--redact` により値がログに出ないことを確認 |
+| BACKLOG 反映 | B10 は「CI 組込み・閾値 SLA」が未決のため枠は動かさない(ローカル検査の先行導入である旨を BACKLOG の de facto 状態に追記) |
+
+### PR 1-4: 開発体験の小物(A-7〜A-10)
+
+| 項目 | 内容 |
+| --- | --- |
+| 作業 | ① actionlint を `mise.toml` + `.makefiles/github/lint.mk` に先行移植(workflows 不在でも空振りするだけ。B9 の受け皿)② `make_help` の未文書化 `.PHONY` 警告を既存 `scripts/make_help.sh` に追補(または `.mjs` 版へ置換)③ `scripts/setup/` に `replace-repository-reference` と `package.json` name 書換(go module rename の翻案)を追加。共有 lib(`--dry-run` / `updateFile`)は既存 `scripts/setup/lib/` に統合 |
+| 触る保護対象 | `mise.toml` / `Makefile` / `.makefiles/` / `scripts/` |
+| 完了条件 | `make help` が全ターゲットを説明付きで列挙し、説明欠落に警告を出す / setup スクリプトが `--dry-run` で変更予定を表示する |
+
+**Phase 1 完了の定義**: PR 1-1〜1-4 マージ済み + BACKLOG G2 更新 + 「速い hook(ローカル)↔ 権威 CI」二重化構造の hook 側が完成している。
+
+---
+
+## Phase 2: CI 基盤(Tier B — B9 / B10 ADR 策定が前提)
+
+**ゴール**: `.github/workflows/` を初導入し、PR ゲート + セキュリティスキャン + 供給網防御を CI 側に立てる。
+
+### Step 2-0: ADR 策定(実装前の必須ゲート)
+
+- **B9(CI 構成方針)**: job 分割(lint+typecheck / build / 将来 test)、required check、pnpm store + Next.js build cache 戦略、hook との二重化境界、workflow 衛生規約(SHA ピン / concurrency / 最小 permissions / ログの PR コメント化)を決める。インベントリ Tier B の B-1〜B-4 が設計材料
+- **B10(セキュリティ運用)**: `pnpm audit` / trivy の閾値と SLA、Dependabot 採用(npm + github-actions、cooldown 段階制 patch 5 日 / minor 7 日 / major 30 日)、SECURITY.md、gitleaks の CI 組込みを決める
+- 成果物: `docs/adr/` に ADR 2 本(ドラフトは AI が作成可、**Accepted 判断はユーザ**)。ADR ファイル新規作成は事前のユーザ指示が必要
+
+### PR 2-1: CI 骨格 + 基本ゲート
+
+- `upsert-pr-comment` composite action を as-is 移植(全 workflow のレポーティング基盤。最初に入れる)
+- lint + typecheck workflow(`pnpm lint` + `tsc --noEmit`)/ build workflow(`pnpm build`)/ lockfile drift(`pnpm install --frozen-lockfile`)
+- 起動スモーク(`pnpm build` → `next start` → `curl /` ポーリング、`timeout-minutes` 付き)
+- 全 workflow に B9 で決めた衛生規約を適用。`.github/workflows/README.md`(トリガー戦略表)を同梱
+
+### PR 2-2: セキュリティ CI(B10 実装)
+
+- CodeQL(`languages: javascript-typescript`、PR + push baseline + 週次 cron `0 0 * * 1`)
+- gitleaks workflow(全 PR)/ trivy-fs 二段(dev PR = fixable のみ・非ブロック / release 向け PR = unfixed 含む全量レポート)
+- `dependabot.yml`(npm + github-actions、cooldown 段階制、ecosystem 単位グループ PR)
+- `SECURITY.md`(報告窓口・SLA。go 側前半のみ、検証 runbook は対象外)
+
+### PR 2-3: Actions SHA ピン留め(BACKLOG C-6 と統合)
+
+- go 側 `scripts/pin-actions/`(Go)を **TS 書換**: `resolve` / `apply` / `check` 3 サブコマンド、lockfile `.github/actions-pin.toml`、検疫 `--min-age-days`(既定 14)
+- `pin-actions-check` workflow + `make pin-actions-*` ターゲット + `.claude/skills/actions-pin` スキル(C-6)を同時に導入
+- PR 2-1 / 2-2 の workflow は本 PR で全 `uses:` を SHA ピンに揃える(2-1 時点では暫定タグ参照を許容)
+
+**Phase 2 完了の定義**: B9 / B10 が Accepted + required check が branch ruleset に反映 + BACKLOG B9 / B10 / C-6 更新 + AGENTS.md の該当 `[TODO]` セクション削除(ユーザ承認のもと)。
+
+---
+
+## Phase 3: docs ポータル(Tier C — D1 / D2 決定が前提)
+
+**ゴール**: docs を GitHub Pages で閲覧可能な portal として配信し、EN/JA ペア運用を規約化する。
+
+1. **Step 3-0**: D1(canonical EN / JA ペア運用)・D2(portal 登録基準と責務分担)の ADR 策定
+2. **PR 3-1**: portal 基盤移植 — `docs/portal/manifest.yaml` + `scripts/{gen-portal-docs,gen-docs-json,build-portal}.mjs` + React SPA。Go 結合ゼロのため翻案は manifest 中身 / タイトル / EN・JA パス規約 / 除外リストのみ。deps(js-yaml / zod / esbuild / marked / fuse.js / highlight.js / react)は pnpm devDependencies に配置(Toolchain-0005 準拠)
+3. **PR 3-2**: `deploy-docs` workflow(Pages 配信。Phase 2 完了後)+ BACKLOG「対象外(D)」の `portal-manifest-sync` スキル復活(C-4 の SECURITY.md 掲載などと合わせ、`readme-review` → manifest 登録の運用ループを閉じる)
+4. 任意: ADR タクソノミー(decision / exclusion / rule / inventory)の部分採用を D1 と同時に検討(採番は本リポの系列プレフィックス方式を維持)
+
+**完了の定義**: portal が Pages で閲覧可能 + manifest 経由の登録フローがスキルで回る + BACKLOG D1 / D2 更新。
+
+## Phase 4: 環境変数・型付き Config(Tier D — A7 決定が前提)
+
+1. **Step 4-0**: A7 ADR 策定 — `env/.env.{local,ci,dev,stg,prd}` レイアウト vs Next.js 標準 `.env.local` 系、`NEXT_PUBLIC_` 境界、シークレットの PaaS ストアマッピング。go 側の envspec / model / config 三点セットと `env/README.md` 変数表が参照設計
+2. **PR 4-1**: zod ベースの型付き Config loader(`parse → validate → freeze` の factory、server / client 分離)+ `env/` レイアウト + 変数表 README
+3. **PR 4-2**: `new-env` スキル再設計(Dev-0005 記載の既知課題。go 由来パス前提を A7 決定後の実パスに差し替え)— `.claude/` 変更のためユーザ指示必須
+
+## Phase 5: テスト基盤(Tier E — B8 決定が前提)
+
+1. **Step 5-0**: B8 ADR 策定(フレームワーク / 配置・命名 / カバレッジ目標 / Server Components の扱い)
+2. **PR 5-1**: フレームワーク導入 + `make test` / `test-cached`(CI = 厳格・キャッシュ無効 / pre-commit = 高速・キャッシュ有効の二層)+ lefthook 接続
+3. **PR 5-2**: カバレッジゲート(`cover-gate` 閾値 + octocov 相当の PR レポート)を CI に追加(B9 の枠組みに載せる)
+4. 連動: BACKLOG C-5(テスト scaffold スキル)、full-apply / node-upgrade / repo-ops スキルの `pnpm test` 条件分岐見直し
+
+---
+
+## マイルストーン一覧
+
+| Phase | 前提 ADR | PR 数目安 | 主な成果物 | BACKLOG 反映 |
+| --- | --- | --- | --- | --- |
+| 1 | なし(G2 は Accepted 済) | 4 | lefthook / commitlint / md+mermaid lint / gitleaks / trivy / setup 拡充 | G2 → ✅/✅ |
+| 2 | B9・B10(要策定) | 3 | workflows 初導入 / upsert-pr-comment / CodeQL / dependabot / actions-pin(TS) | B9・B10 → ✅/✅、C-6 消化 |
+| 3 | D1・D2(要策定) | 2 | docs portal + Pages 配信 + manifest 運用スキル | D1・D2 → ✅/✅ |
+| 4 | A7(要策定) | 2 | env/ レイアウト + zod Config + new-env 再設計 | A7 → ✅/✅ |
+| 5 | B8(要策定) | 2 | テストフレームワーク + カバレッジゲート | B8 → ✅/✅、C-5 消化 |
+
+## リスクと注意点
+
+- **既存 md への初回 lint 指摘量**(PR 1-2): 想定より多い場合はルール調整の判断をユーザに仰ぐ。`md-fix` の一括変更は独立コミット(`Style:`)に分離
+- **ツールのバージョン選定**: gitleaks / trivy / actionlint は `tools-upgrade` スキルの検疫方針(min_age_days)に従い、最新すぎる版を避ける
+- **lefthook 導入直後の摩擦**: pre-push の secret-scan / (将来) test が遅い場合は glob スコープと並列化で調整。フック無効化での回避(`--no-verify` 常用)を常態化させない — ただし `/commit` スキルの設計上のバイパスは除く
+- **AGENTS.md の `[TODO]` セクションとの整合**: 各 Phase 完了時に該当セクションの「暫定挙動」記述が実態と乖離しないか確認し、乖離があれば AGENTS.md 更新をユーザに提案する(AGENTS.md は保護対象のため直接編集しない)
+- **go 側との二重管理**: 移植後に go-boilerplate 側が改善された場合の追従は自動化しない。必要になった時点で本インベントリを再走査する(one-off 方針)


### PR DESCRIPTION
# 概要

隣接リポジトリ go-boilerplate のリポジトリ機能(make ターゲット / CI workflows / scripts / ドキュメント基盤 / セキュリティ運用)を全数調査し、本リポジトリをアプリケーションファウンデーション / プロダクションレディへ引き上げるための移植候補インベントリを docs/ 配下に追加します。既存 BACKLOG の「Claude 資産移植バックログ」(.claude/ スキル)とは別軸の、リポジトリ機能そのものが対象です。

## 変更内容

- **ドキュメント追加**: `docs/go-boilerplate-feature-port-candidates.md`(新規 1 ファイル、127 行)
  - Tier A: ADR ブロッカーなしで即移植可能な候補(lefthook / commitlint / markdownlint + mermaid-lint / gitleaks / trivy fs 等 10 項目)と推奨着手順
  - Tier B: B9(CI 構成)決定時の設計材料(workflow 共通衛生規約 / upsert-pr-comment / actions SHA ピン留め / dependabot cooldown / CodeQL / trivy 二段ゲート等の翻案表)
  - Tier C〜E: D1/D2(docs ポータル)・A7(型付き Config loader)・B8(カバレッジゲート)決定待ちの参照設計
  - ADR 0004(no-docker)等と非互換な不適用一覧、および BACKLOG 枠 ID に紐づけた推奨ロードマップ

## 動作確認方法

- `docs/go-boilerplate-feature-port-candidates.md` を開き、Tier 分類・BACKLOG 枠 ID の紐づけ・既移植分(.makefiles/github、semver、setup 等)との重複がないことを確認
- `pnpm lint` が通ること(確認済み: biome は Markdown 対象外設定)

🤖 Generated with [Claude Code](https://claude.com/claude-code)